### PR TITLE
Added 'path: '/wd/hub/' to config and readme for 404 error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ exports.config = {
    
     hostname: 'hub.crossbrowsertesting.com',
     port: 80,
+    path: '/wd/hub',
    
     services: ['crossbrowsertesting'],
     user: process.env.CBT_USERNAME,
@@ -186,6 +187,7 @@ exports.config = {
   runner: 'local',
   hostname: "hub.crossbrowsertesting.com",
   port: 80,
+  path: '/wd/hub',
   user: 'you@yourdomain.com',		// the email address associated with your CBT account
   key: 'yourauthkey',      					// find this under the "Manage Account page of our app"
   

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -3,6 +3,7 @@ exports.config = {
 
     hostname: 'hub.crossbrowsertesting.com',
     port: 80,
+    path: '/wd/hub',
 
     services: ['crossbrowsertesting'],
     user: process.env.CBT_USERNAME,


### PR DESCRIPTION
Problem = Launching the test causes a 404 Error: ERROR Unable to handle request - Invalid endpoint or request. (/session) 

Solution = Specifying the path in config can remedy the 404 error.
hostname: 'hub.crossbrowsertesting.com',
port: 80,
**path: '/wd/hub',**


